### PR TITLE
Fixed score remains same after going to previous question

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,31 +31,36 @@ const container = document.querySelector(".container");
 date.innerHTML = new Date().getFullYear();
 
 // Define the quiz questions and answers
-const quizData = [
+let quizData = [
     {
         question: "What is the capital of Nigeria?",
         options: ["Abuja", "Lagos", "Aso rock", "Makurdi"],
-        answer: 1
+        answer: 1,
+        correctAnswer: false
     },
     {
         question: "Who is the first president of Nigeria?",
         options: ["Bola Ahmed Tinubu","Dr. Nnamdi Azikiwe", "Gen. Muhammadu Buhari", "Alh. Shehu Shagari"],
-        answer: 2
+        answer: 2,
+        correctAnswer: false
     },
     {
         question: "How many states are in Nigeria?",
         options: ["36", "50", "37", "30"],
-        answer: 1
+        answer: 1,
+        correctAnswer: false
     },
     {
         question: "Where is the Eiffel tower located?",
         options: ["Ontario", "London", "Paris", "Abeokuta"],
-        answer: 3
+        answer: 3,
+        correctAnswer: false
     },
     {
         question: "Which of this is a coastal city?",
         options: ["Enugu", "Owerri", "Lagos", "Kebbi"],
-        answer: 3
+        answer: 3,
+        correctAnswer: false
     }
 ];
 
@@ -106,8 +111,9 @@ function checkAnswer() {
     }
     const selectedAnswer = parseInt(selectedOption.value);
     if (selectedAnswer === quizData[currentQuestion].answer) {
-        score++;
-        return;
+        quizData[currentQuestion].correctAnswer = true;
+    } else {
+        quizData[currentQuestion].correctAnswer = false;
     }
 }
 
@@ -124,11 +130,18 @@ function checkAnswer() {
 //     }
 // }
 
+//Calculate score by checking how many of the answers are correct
+function calculateScore() {
+    quizData.forEach((question) => {
+        if (question.correctAnswer === true) score++;
+    });
+}
 
 
 
 // End the quiz and show the result
 function endQuiz() {
+    calculateScore();
     clearInterval(timer);
         quiz.style.display = "none";
         resultEl.style.display = "inline";


### PR DESCRIPTION
Added a new property to each of the questions in quizData, 'correctAnswer', which should have a value of either true or false.

Changed the logic in the checkAnswer function to change the 'correctAnswer' to true/false whether the selected answer is correct/incorrect.

Then added a new function calculateScore which goes through quizData at the end of the quiz and adds +1 to score if correctAnswer is true for each of the questions. This function gets called in endQuiz.